### PR TITLE
moved density comment to properties from parameters

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -41,7 +41,31 @@ class Radial1DModel(HDFWriterMixin):
         The complete array of the velocities, without being cut by
         `v_boundary_inner` and `v_boundary_outer`
     electron_densities : astropy.units.quantity.Quantity
+
+    Attributes
+    ----------
+    
+    w : numpy.ndarray
+        Shortcut for `dilution_factor`
+    t_rad : astropy.units.quantity.Quantity
+        Shortcut for `t_radiative`
+    radius : astropy.units.quantity.Quantity
+    r_inner : astropy.units.quantity.Quantity
+    r_outer : astropy.units.quantity.Quantity
+    r_middle : astropy.units.quantity.Quantity
+    v_inner : astropy.units.quantity.Quantity
+    v_outer : astropy.units.quantity.Quantity
+    v_middle : astropy.units.quantity.Quantity
+    density : astropy.units.quantity.Quantity
+    volume : astropy.units.quantity.Quantity
+    no_of_shells : int
+        The number of shells as formed by `v_boundary_inner` and
+        `v_boundary_outer`
+    no_of_raw_shells : int
+
+
     """
+
     hdf_properties = ['t_inner', 'w', 't_radiative', 'v_inner', 'v_outer', 'homologous_density']
     hdf_name = 'model'
 
@@ -88,7 +112,6 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def w(self):
-        """Shortcut for `dilution_factor`"""
         return self.dilution_factor
 
     @w.setter
@@ -97,7 +120,6 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def t_rad(self):
-        """Shortcut for `t_radiative`"""
         return self.t_radiative
 
     @t_rad.setter
@@ -125,22 +147,18 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def radius(self):
-        """radius : astropy.units.Quantity"""
         return self.time_explosion * self.velocity
 
     @property
     def r_inner(self):
-        """r_inner : astropy.units.Quantity"""
         return self.time_explosion * self.v_inner
 
     @property
     def r_outer(self):
-        """r_outer : astropy.units.Quantity"""
         return self.time_explosion * self.v_outer
 
     @property
     def r_middle(self):
-        """r_middle : astropy.units.Quantity"""
         return 0.5 * self.r_inner + 0.5 * self.r_outer
 
     @property
@@ -154,22 +172,18 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def v_inner(self):
-        """v_inner : astropy.units.Quantity"""
         return self.velocity[:-1]
 
     @property
     def v_outer(self):
-        """v_outer : astropy.units.Quantity"""
         return self.velocity[1:]
 
     @property
     def v_middle(self):
-        """v_middle : astropy.units.Quantity"""
         return 0.5 * self.v_inner + 0.5 * self.v_outer
 
     @property
     def density(self):
-        """density : astropy.units.quantity.Quantity"""
         density = self.homologous_density.calculate_density_at_time_of_simulation(self.time_explosion)
         return density[self.v_boundary_inner_index
                        :self.v_boundary_outer_index][1:]
@@ -191,19 +205,14 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def volume(self):
-        """volume : astropy.units.Quantity"""
         return ((4. / 3) * np.pi * (self.r_outer ** 3 - self.r_inner ** 3)).cgs
 
     @property
     def no_of_shells(self):
-        """#no_of_shells : int
-            The number of shells as formed by `v_boundary_inner` and
-            `v_boundary_outer`"""
         return len(self.velocity) - 1
 
     @property
     def no_of_raw_shells(self):
-        """no_of_raw_shells : int"""
         return len(self.raw_velocity) - 1
 
     @property

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -29,6 +29,7 @@ class Radial1DModel(HDFWriterMixin):
     time_explosion : astropy.units.Quantity
         Time since explosion
     t_inner : astropy.units.Quantity
+    luminosity_requested : astropy.units.quantity.Quantity
     t_radiative : astropy.units.Quantity
         Radiative temperature for the shells
     dilution_factor : np.ndarray
@@ -39,7 +40,7 @@ class Radial1DModel(HDFWriterMixin):
     raw_velocity : np.ndarray
         The complete array of the velocities, without being cut by
         `v_boundary_inner` and `v_boundary_outer`
-
+    electron_densities : astropy.units.quantity.Quantity
     """
     hdf_properties = ['t_inner', 'w', 't_radiative', 'v_inner', 'v_outer', 'homologous_density']
     hdf_name = 'model'

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -34,27 +34,11 @@ class Radial1DModel(HDFWriterMixin):
     dilution_factor : np.ndarray
         If None, the dilution_factor will be initialized with the geometric
         dilution factor.
-    #v_inner : astropy.units.Quantity
-    #v_middle : astropy.units.Quantity
-    #v_outer : astropy.units.Quantity
-    #r_inner : astropy.units.Quantity
-    #r_middle : astropy.units.Quantity
-    #r_outer : astropy.units.Quantity
-    #radius : astropy.units.Quantity
-    #volume : astropy.units.Quantity
-    #no_of_shells : int
-        The number of shells as formed by `v_boundary_inner` and
-        `v_boundary_outer`
-    #no_of_raw_shells : int
     v_boundary_inner : astropy.units.Quantity
     v_boundary_outer : astropy.units.Quantity
     raw_velocity : np.ndarray
         The complete array of the velocities, without being cut by
         `v_boundary_inner` and `v_boundary_outer`
-    #w : np.ndarray
-        Shortcut for `dilution_factor`
-    #t_rad : astropy.units.Quantity
-        Shortcut for `t_radiative`
 
     """
     hdf_properties = ['t_inner', 'w', 't_radiative', 'v_inner', 'v_outer', 'homologous_density']
@@ -140,18 +124,22 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def radius(self):
+        """radius : astropy.units.Quantity"""
         return self.time_explosion * self.velocity
 
     @property
     def r_inner(self):
+        """r_inner : astropy.units.Quantity"""
         return self.time_explosion * self.v_inner
 
     @property
     def r_outer(self):
+        """r_outer : astropy.units.Quantity"""
         return self.time_explosion * self.v_outer
 
     @property
     def r_middle(self):
+        """r_middle : astropy.units.Quantity"""
         return 0.5 * self.r_inner + 0.5 * self.r_outer
 
     @property
@@ -165,14 +153,17 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def v_inner(self):
+        """v_inner : astropy.units.Quantity"""
         return self.velocity[:-1]
 
     @property
     def v_outer(self):
+        """v_outer : astropy.units.Quantity"""
         return self.velocity[1:]
 
     @property
     def v_middle(self):
+        """v_middle : astropy.units.Quantity"""
         return 0.5 * self.v_inner + 0.5 * self.v_outer
 
     @property
@@ -199,14 +190,19 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def volume(self):
+        """volume : astropy.units.Quantity"""
         return ((4. / 3) * np.pi * (self.r_outer ** 3 - self.r_inner ** 3)).cgs
 
     @property
     def no_of_shells(self):
+        """#no_of_shells : int
+            The number of shells as formed by `v_boundary_inner` and
+            `v_boundary_outer`"""
         return len(self.velocity) - 1
 
     @property
     def no_of_raw_shells(self):
+        """no_of_raw_shells : int"""
         return len(self.raw_velocity) - 1
 
     @property

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -25,7 +25,6 @@ class Radial1DModel(HDFWriterMixin):
         .. note:: To access the entire, "uncut", velocity array,
         use `raw_velocity`
     homologous_density : HomologousDensity
-    density : astropy.units.quantity.Quantity
     abundance : pd.DataFrame
     time_explosion : astropy.units.Quantity
         Time since explosion
@@ -35,26 +34,26 @@ class Radial1DModel(HDFWriterMixin):
     dilution_factor : np.ndarray
         If None, the dilution_factor will be initialized with the geometric
         dilution factor.
-    v_inner : astropy.units.Quantity
-    v_middle : astropy.units.Quantity
-    v_outer : astropy.units.Quantity
-    r_inner : astropy.units.Quantity
-    r_middle : astropy.units.Quantity
-    r_outer : astropy.units.Quantity
-    radius : astropy.units.Quantity
-    volume : astropy.units.Quantity
-    no_of_shells : int
+    #v_inner : astropy.units.Quantity
+    #v_middle : astropy.units.Quantity
+    #v_outer : astropy.units.Quantity
+    #r_inner : astropy.units.Quantity
+    #r_middle : astropy.units.Quantity
+    #r_outer : astropy.units.Quantity
+    #radius : astropy.units.Quantity
+    #volume : astropy.units.Quantity
+    #no_of_shells : int
         The number of shells as formed by `v_boundary_inner` and
         `v_boundary_outer`
-    no_of_raw_shells : int
+    #no_of_raw_shells : int
     v_boundary_inner : astropy.units.Quantity
     v_boundary_outer : astropy.units.Quantity
     raw_velocity : np.ndarray
         The complete array of the velocities, without being cut by
         `v_boundary_inner` and `v_boundary_outer`
-    w : np.ndarray
+    #w : np.ndarray
         Shortcut for `dilution_factor`
-    t_rad : astropy.units.Quantity
+    #t_rad : astropy.units.Quantity
         Shortcut for `t_radiative`
 
     """
@@ -178,6 +177,7 @@ class Radial1DModel(HDFWriterMixin):
 
     @property
     def density(self):
+        """density : astropy.units.quantity.Quantity"""
         density = self.homologous_density.calculate_density_at_time_of_simulation(self.time_explosion)
         return density[self.v_boundary_inner_index
                        :self.v_boundary_outer_index][1:]


### PR DESCRIPTION
Parameters described in the docstring for the model base class should be exactly the parameters needed in the __init__ call.  Descriptions of @properties are being moved to the corresponding properties.